### PR TITLE
Correctly quote directory name in the initContainer script.

### DIFF
--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
               for v in $((btrfs subvolume list --sort=-ogen "{{ .Values.concourse.worker.workDir }}" || true) | awk '{print $9}'); do
                 (btrfs subvolume show "{{ .Values.concourse.worker.workDir }}/$v" && btrfs subvolume delete "{{ .Values.concourse.worker.workDir }}/$v") || true
               done
-              rm -rf "{{ .Values.concourse.worker.workDir }}/*"
+              rm -rf "{{ .Values.concourse.worker.workDir }}"/*
           volumeMounts:
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.worker.workDir | quote }}


### PR DESCRIPTION
The original quoting prevented the globbing expansion to happen,
making workdir content persist across volume restarts. This PR
modifies the behavior to allow for the expansion.

Note: this is not a full-featured fix to this issue (e.g. doesn't
handle dotfiles) and depending on how/whether concourse does any
shell escaping, this might need some further work.

Signed-off-by: Milan Plzik <milan.plzik@ceai.io>