### PR TITLE
worker: fix misuse of quotes + default image bump

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: concourse
-version: 8.2.4
-appVersion: 5.5.0
+version: 8.2.5
+appVersion: 5.5.3
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `imageDigest` | Specific image digest to use in place of a tag. | `nil` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
-| `imageTag` | Concourse image version | `5.5.0` |
+| `imageTag` | Concourse image version | `5.5.3` |
 | `image` | Concourse image | `concourse/concourse` |
 | `nameOverride` | Provide a name in place of `concourse` for `app:` labels | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |

--- a/templates/worker-statefulset.yaml
+++ b/templates/worker-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
               for v in $((btrfs subvolume list --sort=-ogen "{{ .Values.concourse.worker.workDir }}" || true) | awk '{print $9}'); do
                 (btrfs subvolume show "{{ .Values.concourse.worker.workDir }}/$v" && btrfs subvolume delete "{{ .Values.concourse.worker.workDir }}/$v") || true
               done
-              rm -rf "{{ .Values.concourse.worker.workDir }}/*"
+              rm -rf "{{ .Values.concourse.worker.workDir }}"/*
           volumeMounts:
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.worker.workDir | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ image: concourse/concourse
 ##      of `concourse/concourse`.
 ## Ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "5.4.1"
+imageTag: "5.5.3"
 
 ## Specific image digest to use in place of a tag.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/overview/#container-images


### PR DESCRIPTION
Previously, we were making incorrect use of quotes in the script that
was used to remove the state that was left behind from previous runs
(see https://github.com/concourse/charts/issues/6)

This commit is a backport of the helm/charts#17920, including a bump to
the default versions so that we use the latest ones.
